### PR TITLE
id:JMapを削除

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,15 +31,11 @@
   padding: 10px;
 }
 
-#JMap{
+#japanmap{
   display: block;
   position: absolute;
   top: 20px;
   right: 20px;
-}
-
-
-#japanmap{
   width: 180px;
   height: 180px;
 }

--- a/src/Card.js
+++ b/src/Card.js
@@ -21,7 +21,7 @@ function Card(props) {
                         <span onClick={toggleLike}>{liked ? '🤟' : '♡'}</span>
                     </div>
 
-                    <div id="JMap">
+                    <div>
                         <JapanMap clicked={props.clicked}/> 
                     </div>
                     


### PR DESCRIPTION
## 概要

* App.cssにおいてid、JMapとjapanmapの役割が同じであるにも関わらず分割されて書かれていたためJMapを削除しjapanmapに結合した。

*Card.jsで対応するidの宣言を削除した。

## 技術的変更点概要

* App.cssにおいて#JMap{}を削除、内容を#japanmap内に移行。

* Card.jsにおいて対応する箇所の\<var id="JMap">内のid部分を削除。

## テスト結果とテスト項目

* [ ] Chromeで閲覧フォームを表示、地図の位置がずれていないか、地図の大きさが正常であるか確認

## 今回保留した項目とTODOリスト

* App.css内に複数のjsへのcssを記入しているのでそれぞれのcssに分ける